### PR TITLE
Changed the usage of ManipulationHandler to ObjectManipulator in the BoundingBoxStateController

### DIFF
--- a/Frontend/VIAProMa/Assets/Scripts/Utilities/BoundingBoxStateController.cs
+++ b/Frontend/VIAProMa/Assets/Scripts/Utilities/BoundingBoxStateController.cs
@@ -9,7 +9,7 @@ public class BoundingBoxStateController : MonoBehaviour
 {
     private BoundingBox boundingBox;
     private BoxCollider boxCollider;
-    private ManipulationHandler manipulationHandler;
+    private ObjectManipulator manipulationHandler;
     private bool boundingBoxActive;
 
     public event EventHandler BoundingBoxStateChanged;
@@ -37,7 +37,7 @@ public class BoundingBoxStateController : MonoBehaviour
         {
             SpecialDebugMessages.LogComponentNotFoundError(this, nameof(BoxCollider), gameObject);
         }
-        manipulationHandler = GetComponent<ManipulationHandler>();
+        manipulationHandler = GetComponent<ObjectManipulator>();
         // manipulation handler is optional, so no check here
     }
 


### PR DESCRIPTION
In the new MRTK version, the object manipulation is handeld through ObjectManipulator components and not through ManipulationHandlers anymore. The BoundingBoxStateController however still tried to use the ManipulationHandler, which was then always null.