### PR TITLE
Fixed github label id type

### DIFF
--- a/Backend/src/main/i5/las2peer/services/immersiveProjectManagementService/i5/las2peer/services/immersiveProjectManagementService/dataModel/gitHub/GitHubLabel.java
+++ b/Backend/src/main/i5/las2peer/services/immersiveProjectManagementService/i5/las2peer/services/immersiveProjectManagementService/dataModel/gitHub/GitHubLabel.java
@@ -7,13 +7,13 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class GitHubLabel {
-    private int id;
+    private long id;
     private String nodeId;
     private String name;
     private String description;
     private String color;
 
-    public int getId() {
+    public long getId() {
         return id;
     }
 

--- a/Backend/src/test/i5/las2peer/services/immersiveProjectManagementService/GitHubConnectorTest.java
+++ b/Backend/src/test/i5/las2peer/services/immersiveProjectManagementService/GitHubConnectorTest.java
@@ -87,6 +87,7 @@ public class GitHubConnectorTest {
         APIResult<GitHubIssue[]> result = GitHubConnector.getIssuesInRepository("microsoft", "MixedRealityToolkit-Unity", 0, 10);
         if (result.hasError())
         {
+            System.out.println("Result has error");
             System.out.println(result.getErrorMessage());
         }
         Assert.assertTrue(result.successful());


### PR DESCRIPTION
Fixes #188 by converting the label id to long instead of int.

The unit tests of the backend now pass again.