### PR TITLE
The grid shader now supports single pass instanced rendering

### DIFF
--- a/Frontend/VIAProMa/Assets/Scripts/Visualizations/Diagrams/Common/Grid/GridShader.shader
+++ b/Frontend/VIAProMa/Assets/Scripts/Visualizations/Diagrams/Common/Grid/GridShader.shader
@@ -1,4 +1,6 @@
-﻿Shader "Custom/Grid Shader"
+﻿// Upgrade NOTE: replaced 'UNITY_INSTANCE_ID' with 'UNITY_VERTEX_INPUT_INSTANCE_ID'
+
+Shader "Custom/Grid Shader"
 {
 	Properties
 	{
@@ -41,25 +43,33 @@
 			{
 				float4 position : POSITION;
 				float2 uv : TEXCOORD0;
+				UNITY_VERTEX_INPUT_INSTANCE_ID
 			};
 
 			struct v2f
 			{
 				float4 position : SV_POSITION;
 				float2 uv : TEXCOORD0;
+				UNITY_VERTEX_INPUT_INSTANCE_ID
+				UNITY_VERTEX_OUTPUT_STEREO
 			};
 
 
 			v2f vert(vertexData input)
 			{
 				v2f o;
+				UNITY_SETUP_INSTANCE_ID(input);
+				UNITY_TRANSFER_INSTANCE_ID(input, o);
+				UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(o);
 				o.position = UnityObjectToClipPos(input.position);
 				o.uv = input.uv;
 				return o;
 			}
 
+
 			float4 frag(v2f input) : SV_TARGET
 			{
+				UNITY_SETUP_INSTANCE_ID(input);
 				if (frac((input.uv.x + _OffsetX + _WireThicknessX / 2.0) / _CellWidth) < (_WireThicknessX / _CellWidth)
 				|| frac((input.uv.y + _OffsetY + _WireThicknessY / 2.0) / _CellHeight) < (_WireThicknessY / _CellHeight))
 				{


### PR DESCRIPTION
VIAProMa uses single pass instanced rendering. Shaders need to explicitly support this, in order to be rendered correctly. The grid shader didn't support the instanced rendering and as a result was only rendered on one eye. This PR updates the grid shader to support it.
Closes #123