### PR TITLE
Fixed unkown property error in Requirements Bazaar projects

### DIFF
--- a/Backend/src/main/i5/las2peer/services/immersiveProjectManagementService/i5/las2peer/services/immersiveProjectManagementService/dataModel/requirementsBazaar/ReqBazProject.java
+++ b/Backend/src/main/i5/las2peer/services/immersiveProjectManagementService/i5/las2peer/services/immersiveProjectManagementService/dataModel/requirementsBazaar/ReqBazProject.java
@@ -1,9 +1,11 @@
 package i5.las2peer.services.immersiveProjectManagementService.i5.las2peer.services.immersiveProjectManagementService.dataModel.requirementsBazaar;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 /**
  * Created by bened on 10.05.2019.
  */
-//@JsonFilter("shortFilter")
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ReqBazProject {
     public int id;
     public String name;


### PR DESCRIPTION
Fixes #286.

Additional properties in the JSON response are now set to be ignored. This makes the conversion process more stable as newly added properties in the Requirements Bazaar that are irrelevant for VIAProMa do not break the API.