### PR TITLE
Fixes nullref exeption in GitHub Issuecards

### DIFF
--- a/Frontend/VIAProMa/Assets/Scripts/IssueEditing/DeleteButtonOpener.cs
+++ b/Frontend/VIAProMa/Assets/Scripts/IssueEditing/DeleteButtonOpener.cs
@@ -38,7 +38,7 @@ public class DeleteButtonOpener : MonoBehaviour
             buttonInstance.SetActive(ServiceManager.GetService<LearningLayersOidcService>().IsLoggedIn);
             buttonInstance.transform.parent = this.transform.parent.parent.parent;
         }
-        if(buttonInstance.transform.position != new Vector3(this.transform.position.x + 0.08f, this.transform.position.y + 0.1f, this.transform.position.z))
+        if(buttonInstance != null && buttonInstance.transform.position != new Vector3(this.transform.position.x + 0.08f, this.transform.position.y + 0.1f, this.transform.position.z))
         {
             buttonInstance.transform.position = new Vector3(this.transform.position.x + 0.08f, this.transform.position.y + 0.1f, this.transform.position.z);
         }


### PR DESCRIPTION
Issue cards only recive a DeleteButton, when the RequirementsBazaar is used and not GitHub, since GitHub issues can only be closed and not deleted. DeleteButtonOpener tried to manilpulate this button, even when GitHub was used, which resulted in null exeptions.

Closes #403 