### PR TITLE
Moved issue shelf to the left

### DIFF
--- a/Frontend/VIAProMa/Assets/Scripts/UI/Main Menu Cube/MainMenu.cs
+++ b/Frontend/VIAProMa/Assets/Scripts/UI/Main Menu Cube/MainMenu.cs
@@ -184,7 +184,7 @@ namespace i5.VIAProMa.UI.MainMenuCube
 
         public void ShowIssueShelf()
         {
-            Vector3 targetPosition = transform.position - 1f * transform.right;
+            Vector3 targetPosition = transform.position - 2f * transform.right;
             targetPosition.y = 0f;
             SceneNetworkInstantiateControl(issueShelfPrefab, ref issueShelfInstance, targetPosition, IssueShelfCreated);
             foldController.InitalizeNewCloseTimer();


### PR DESCRIPTION
Simply moves the issue shelf to the left to avoid clipping. I experimented with dynamic positions, i.e. when the visualisation shelf is not loaded, the issue shelf is palced directly left to the cube and only farther left when the vis shelf is there, but that seemed to be annoying since it made a bit unintuitive where which shelf spawns.
I also tried rotating the shelf toward the user a bit, but that made placing visualisations a bit more annoying.

![grafik](https://user-images.githubusercontent.com/59895994/154965129-3bc3d03e-be65-4c7c-be24-34f46a21a093.png)

Closes #288
