### PR TITLE
Folder positioning/rotation now also works when shelf was rotated

### DIFF
--- a/Frontend/VIAProMa/Assets/Scripts/RotateOnFocus.cs
+++ b/Frontend/VIAProMa/Assets/Scripts/RotateOnFocus.cs
@@ -20,7 +20,7 @@ namespace i5.VIAProMa
 
         private void Update()
         {
-            transform.localRotation = Quaternion.Lerp(transform.rotation, Quaternion.Euler(targetRotation), Time.deltaTime * damping);
+            transform.localRotation = Quaternion.Lerp(transform.localRotation, Quaternion.Euler(targetRotation), Time.deltaTime * damping);
         }
 
         public override void OnFocusEnter(FocusEventData eventData)


### PR DESCRIPTION
The [RotateOnFocus](https://github.com/rwth-acis/VIAProMa/blob/develop/Frontend/VIAProMa/Assets/Scripts/RotateOnFocus.cs) class lerps the folder to a target rotation that depends on the folder being in focus or not. For this lerp prcocess, the global rotation was used, but the target rotation was given as local rotation. Therfore, the folders where constantly rotating as soon as the local rotation didn't equal the global anymore (i.e. when the shelf was rotated).

Now the local rotation is used and [RotateOnFocus](https://github.com/rwth-acis/VIAProMa/blob/develop/Frontend/VIAProMa/Assets/Scripts/RotateOnFocus.cs) works also when the shelf was rotated.

Closes #413