### PR TITLE
Requirements Bazaar Profile Image Fix

### DIFF
--- a/Frontend/VIAProMa/Assets/Scripts/DataDisplays/UserDataDisplay.cs
+++ b/Frontend/VIAProMa/Assets/Scripts/DataDisplays/UserDataDisplay.cs
@@ -105,8 +105,8 @@ namespace i5.VIAProMa.DataDisplays
             if (string.IsNullOrEmpty(user.ProfileImageUrl) || user.ProfileImageUrl == "https://api.learning-layers.eu/profile.png" || nonfunctionalProfileURLs.ContainsKey(user.Id))
             {
                 // try and fetch the profile image from Gravatar 
-                //if (user.EMail != null)
-                //{
+                if (user.EMail != null)
+                {
                     ApiResult<Texture2D> res = await FetchProfileImageFromGravatar(user);
                     if (res.Successful)
                     {
@@ -116,12 +116,12 @@ namespace i5.VIAProMa.DataDisplays
                     {
                         return ResourceManager.Instance.DefaultProfileImage;
                     }
-                //}
+                }
                 // otherwise the default profile image
-                //else
-                //{
-                //return ResourceManager.Instance.DefaultProfileImage;
-                //}
+                else
+                {
+                return ResourceManager.Instance.DefaultProfileImage;
+                }
             }
 
             // first check if we downloaded the profile picture before
@@ -147,8 +147,8 @@ namespace i5.VIAProMa.DataDisplays
                     }
 
                     // try and fetch the profile image from Gravatar instead
-                    //if (user.EMail != null)
-                    //{
+                    if (user.EMail != null)
+                    {
                         res = await FetchProfileImageFromGravatar(user);
                         if (res.Successful)
                         {
@@ -158,12 +158,12 @@ namespace i5.VIAProMa.DataDisplays
                         {
                             return ResourceManager.Instance.DefaultProfileImage;
                         }
-                    //}
+                    }
                     // otherwise the default profile image
-                    //else
-                    //{
-                        //return ResourceManager.Instance.DefaultProfileImage;
-                    //}
+                    else
+                    {
+                        return ResourceManager.Instance.DefaultProfileImage;
+                    }
                 }
             }
         }
@@ -198,10 +198,7 @@ namespace i5.VIAProMa.DataDisplays
         private static async Task<ApiResult<Texture2D>> FetchProfileImageFromGravatar(User user)
         {
             // create hash from email
-            //string hashedEmail = CreateMD5(user.EMail.Trim().ToLower());
-
-            // Temporary email, until the user email is successfully fetched
-            string hashedEmail = CreateMD5("emilie.hastrup.kiil@rwth-aachen.de");
+            string hashedEmail = CreateMD5(user.EMail.Trim().ToLower());
 
             // request gravatar image
             UnityWebRequest www = UnityWebRequestTexture.GetTexture("https://www.gravatar.com/avatar/" + hashedEmail + "?r=g&d=404");

--- a/Frontend/VIAProMa/Assets/Scripts/DataDisplays/UserDataDisplay.cs
+++ b/Frontend/VIAProMa/Assets/Scripts/DataDisplays/UserDataDisplay.cs
@@ -24,6 +24,8 @@ namespace i5.VIAProMa.DataDisplays
 
         private static Dictionary<string, Texture2D> profileImages = new Dictionary<string, Texture2D>();
 
+        private static Dictionary<int, string> nonfunctionalProfileURLs = new Dictionary<int, string>();
+
         /// <summary>
         /// Checks the setup of the component
         /// </summary>
@@ -97,7 +99,8 @@ namespace i5.VIAProMa.DataDisplays
         /// <returns>The profile image of the given user</returns>
         private static async Task<Texture2D> GetProfileImage(User user)
         {
-            if (string.IsNullOrEmpty(user.ProfileImageUrl))
+            // check whether the url can be used to fetch a profile image
+            if (string.IsNullOrEmpty(user.ProfileImageUrl) || user.ProfileImageUrl == "https://api.learning-layers.eu/profile.png" || nonfunctionalProfileURLs.ContainsKey(user.Id))
             {
                 return ResourceManager.Instance.DefaultProfileImage;
             }
@@ -116,7 +119,13 @@ namespace i5.VIAProMa.DataDisplays
                 }
                 else
                 {
-                    Debug.LogError(res.ResponseCode + ": " + res.ErrorMessage);
+                    // Check and add the url to the dictionary, as it is not functional
+                    if (!nonfunctionalProfileURLs.ContainsKey(user.Id))
+                    {
+                        nonfunctionalProfileURLs.Add(user.Id, user.ProfileImageUrl);
+                        Debug.LogError(res.ResponseCode + ": " + res.ErrorMessage);
+                        Debug.Log("The profile image of the user " + user.UserName + " could not be fetched.");
+                    }
                     return ResourceManager.Instance.DefaultProfileImage;
                 }
             }

--- a/Frontend/VIAProMa/Assets/Scripts/DataModel/API/User.cs
+++ b/Frontend/VIAProMa/Assets/Scripts/DataModel/API/User.cs
@@ -16,6 +16,8 @@ namespace i5.VIAProMa.DataModel.API
         [SerializeField] private string firstName;
         [SerializeField] private string lastName;
         [SerializeField] private string profileImageUrl;
+        [SerializeField] private string eMail;
+
 
         /// <summary>
         /// The data source where this user is registered
@@ -41,12 +43,16 @@ namespace i5.VIAProMa.DataModel.API
         /// The url to the profile image
         /// </summary>
         public string ProfileImageUrl { get => profileImageUrl; }
+        /// <summary>
+        /// The users email
+        /// </summary>
+        public string EMail { get => eMail; }
 
         public User()
         {
         }
 
-        public User(DataSource source, int id, string userName, string firstName, string lastName, string profileImageUrl)
+        public User(DataSource source, int id, string userName, string firstName, string lastName, string profileImageUrl, string eMail)
         {
             this.source = source;
             this.id = id;
@@ -54,6 +60,7 @@ namespace i5.VIAProMa.DataModel.API
             this.firstName = firstName;
             this.lastName = lastName;
             this.profileImageUrl = profileImageUrl;
+            this.eMail = eMail;
         }
     }
 }

--- a/Frontend/VIAProMa/Assets/Tests/Visualizations/CompetenceDisplayTest/CompetenceDisplayTestRunner.cs
+++ b/Frontend/VIAProMa/Assets/Tests/Visualizations/CompetenceDisplayTest/CompetenceDisplayTestRunner.cs
@@ -17,7 +17,7 @@ public class CompetenceDisplayTestRunner : MonoBehaviour
             List<UserScore> scores = new List<UserScore>();
             for (int i = 0; i < simulatedCompetences.Length; i++)
             {
-                UserScore score = new UserScore(new User(DataSource.GITHUB, -1, "User " + (i+1), "User " + (i+1), "", ""), 1, 0, 0, 0);
+                UserScore score = new UserScore(new User(DataSource.GITHUB, -1, "User " + (i+1), "User " + (i+1), "", "", ""), 1, 0, 0, 0);
                 Issue issue = new Issue(DataSource.GITHUB, -1, "", "", 0, null, IssueStatus.CLOSED, "", "", null, null);
                 for (int j = 0; j < simulatedCompetences[i]; j++)
                 {


### PR DESCRIPTION
Multiple error messages appear when loading profile images from the Requirements Bazaar, as VIAProMa repeatedly tries to fetch the default profile image url of the user, which does not yield an image. This issue has been resolved by checking for the default url beforehand and introducing a dictionary that stores all non-functional profile image urls. In addition, the basic functions for fetching images directly from Gravatar have been implemented. At this point in time, it is not possible to extract the user email through webrequest to the Requirements Bazaar, thus, the Gravatar function is as of now bypassed and the default image displayed instead.