### PR TITLE
Requirements Bazaar Authorization Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+Backend/immersive_project_management_service/src/main/java/i5/las2peer/services/immersiveProjectManagementService/i5/las2peer/services/immersiveProjectManagementService/dataModel/requirementsBazaar/ReqBazContributors.java

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-
-Backend/immersive_project_management_service/src/main/java/i5/las2peer/services/immersiveProjectManagementService/i5/las2peer/services/immersiveProjectManagementService/dataModel/requirementsBazaar/ReqBazContributors.java

--- a/Frontend/VIAProMa/Assets/Prefabs/Resources/Card In Scene.prefab
+++ b/Frontend/VIAProMa/Assets/Prefabs/Resources/Card In Scene.prefab
@@ -367,12 +367,12 @@ MonoBehaviour:
   ObservedComponentsFoldoutOpen: 1
   Group: 0
   prefixField: -1
-  observableSearch: 0
   Synchronization: 3
   OwnershipTransfer: 2
+  observableSearch: 0
   ObservedComponents:
   - {fileID: 5929660014016528741}
-  viewIdField: 0
+  sceneViewId: 0
   InstantiationId: 1
   isRuntimeInstantiated: 0
 --- !u!114 &5929660014016528741

--- a/Frontend/VIAProMa/Assets/Scripts/IssueEditing/CreateIssueMenu.cs
+++ b/Frontend/VIAProMa/Assets/Scripts/IssueEditing/CreateIssueMenu.cs
@@ -28,13 +28,26 @@ public class CreateIssueMenu : MonoBehaviour
         switch (configurationMenu.ShelfConfiguration.SelectedSource)
         {
             case DataSource.REQUIREMENTS_BAZAAR:
-                Category category;
-                category = await RequirementsBazaarManager.GetCategory(projectTracker.currentCategory.id);
-                Category[] categoryarray = new Category[1];
-                categoryarray[0] = category;
+                int category = 0;
+                Project proj = await RequirementsBazaarManager.GetProject(projectTracker.currentProjectID);
+                int[] categoryarray = null;
+                if (projectTracker.currentCategory.id == 0)
+                {
 
+                    category = proj.DefaultCategoryId;
+                }
+                else
+                {
+                    if (projectTracker.currentCategory.id != 0)
+                    {
+                        category = projectTracker.currentCategory.id;
+                    }
+                }
+                categoryarray = new int[1];
+                categoryarray[0] = category;
                 await RequirementsBazaarManager.CreateRequirement(projectTracker.currentProjectID, issueName.text, issueDescription.text, categoryarray);
                 break;
+
             case DataSource.GITHUB:
                 await GitHubManager.CreateIssue(projectTracker.currentRepositoryOwner,projectTracker.currentRepositoryName, issueName.text, issueDescription.text);
                 break;

--- a/Frontend/VIAProMa/Assets/Scripts/IssueEditing/CreateIssueMenuOpener.cs
+++ b/Frontend/VIAProMa/Assets/Scripts/IssueEditing/CreateIssueMenuOpener.cs
@@ -270,7 +270,7 @@ public class CreateIssueMenuOpener : MonoBehaviour
     //Checks if the Button should be Enabled if a RequirementBazaar Configuration is enabled
     private void RequirementBazaarCheck()
     {
-        if (isloggedIn_RequirementBazaar && isProjectLoaded_RequirementBazaar && categorySelected_RequirementBazaar)
+        if (isloggedIn_RequirementBazaar && isProjectLoaded_RequirementBazaar)
             EnableButton();
         else
             DisableButton();

--- a/Frontend/VIAProMa/Assets/Scripts/IssueEditing/RequirementBazaarAPI/Requirement.cs
+++ b/Frontend/VIAProMa/Assets/Scripts/IssueEditing/RequirementBazaarAPI/Requirement.cs
@@ -17,7 +17,7 @@ namespace Org.Requirements_Bazaar.DataModel
         [SerializeField] private string description;
         [SerializeField] private int projectId;
         [SerializeField] private User creator;
-        [SerializeField] private Category[] categories;
+        [SerializeField] private int[] categories;
         [SerializeField] private string creationDate;
         [SerializeField] private int numberOfComments;
         [SerializeField] private int numberOfAttachments;
@@ -101,7 +101,7 @@ namespace Org.Requirements_Bazaar.DataModel
         /// <summary>
         /// An array of categories to which the requirement belongs
         /// </summary>
-        public Category[] Categories
+        public int[] Categories
         {
             get
             {

--- a/Frontend/VIAProMa/Assets/Scripts/IssueEditing/RequirementBazaarAPI/RequirementsBazaarManager.cs
+++ b/Frontend/VIAProMa/Assets/Scripts/IssueEditing/RequirementBazaarAPI/RequirementsBazaarManager.cs
@@ -12,6 +12,7 @@ using UnityEngine.Networking;
 using i5.Toolkit.Core.OpenIDConnectClient;
 using i5.Toolkit.Core.ServiceCore;
 using i5.VIAProMa.Login;
+using System.Text;
 
 namespace Org.Requirements_Bazaar.API
 {
@@ -51,7 +52,7 @@ namespace Org.Requirements_Bazaar.API
         /// <param name="searchFilter">A search query string</param>
         /// <param name="sortingMode">How the categories should be sorteds</param>
         /// <returns></returns>
-        public static async Task<Category[]> GetProjectCategories (int projectId, int page = 0, int per_page = 10, string searchFilter = "", ProjectSortingMode sortingMode = ProjectSortingMode.DEFAULT)
+        public static async Task<int[]> GetProjectCategories (int projectId, int page = 0, int per_page = 10, string searchFilter = "", ProjectSortingMode sortingMode = ProjectSortingMode.DEFAULT)
         {
             string url = baseUrl + "projects/" + projectId.ToString() + "/categories?page=" + page.ToString() + "&per_page=" + per_page.ToString();
 
@@ -74,7 +75,7 @@ namespace Org.Requirements_Bazaar.API
             else
             {
                 string json = JsonHelper.EncapsulateInWrapper(response.ResponseBody);
-                Category[] categoryList = JsonHelper.FromJson<Category>(json);
+                int[] categoryList = JsonHelper.FromJson<int>(json);
                 return categoryList;
             }
         }
@@ -127,7 +128,7 @@ namespace Org.Requirements_Bazaar.API
         /// </summary>
         /// <param name="categoryId">The ID of the category</param>
         /// <returns>The category</returns>
-        public static async Task<Category> GetCategory(int categoryId)
+        public static async Task<int> GetCategory(int categoryId)
         {
             string url = baseUrl + "categories/" + categoryId.ToString();
 
@@ -141,7 +142,7 @@ namespace Org.Requirements_Bazaar.API
             }
             else
             {
-                Category category = JsonUtility.FromJson<Category>(response.ResponseBody);
+                int category = JsonUtility.FromJson<int>(response.ResponseBody);
                 return category;
             }
         }
@@ -155,17 +156,43 @@ namespace Org.Requirements_Bazaar.API
         {
             string url = baseUrl + "requirements/" + requirementId.ToString();
             Dictionary<string, string> headers = new Dictionary<string, string>();
-            headers.Add("Authorization", "Bearer " + ServiceManager.GetService<LearningLayersOidcService>().AccessToken);
-            Response resp = await Rest.DeleteAsync(url, headers, -1, true);
-            if(!resp.Successful)
+            if (ServiceManager.GetService<LearningLayersOidcService>() != null)
             {
-                Debug.LogError(resp.ResponseCode + ": " + resp.ResponseBody);
+                Debug.Log("Service not null");
+            }
+
+            // decode the access token
+            string decodedToken = JWT_Decoding(ServiceManager.GetService<LearningLayersOidcService>().AccessToken);
+            if (decodedToken == "")
+            {
+                Debug.LogError("Invalid Access Token for Decoding.");
                 return null;
             }
             else
             {
-                Requirement requirement = JsonUtility.FromJson<Requirement>(resp.ResponseBody);
-                return requirement;
+
+                // extract sub and preferred username information and encode for the header
+                string authentificationInfoInfo = GetBasicAuthentificationInfo(decodedToken);
+                byte[] authentificationInfoInfoBytes = Encoding.UTF8.GetBytes(authentificationInfoInfo);
+                string encodedAuthentificationInfo = Convert.ToBase64String(authentificationInfoInfoBytes);
+
+                Debug.Log(encodedAuthentificationInfo);
+
+                headers.Add("Authorization", "Basic " + encodedAuthentificationInfo);
+                headers.Add("access-token", ServiceManager.GetService<LearningLayersOidcService>().AccessToken);
+
+                Debug.Log(headers);
+                Response resp = await Rest.DeleteAsync(url, headers, -1, true);
+                if (!resp.Successful)
+                {
+                    Debug.LogError(resp.ResponseCode + ": " + resp.ResponseBody);
+                    return null;
+                }
+                else
+                {
+                    Requirement requirement = JsonUtility.FromJson<Requirement>(resp.ResponseBody);
+                    return requirement;
+                }
             }
         }
 
@@ -200,18 +227,92 @@ namespace Org.Requirements_Bazaar.API
             {
                 Debug.Log("Service not null");
             }
-            headers.Add("Authorization", "Bearer " + ServiceManager.GetService<LearningLayersOidcService>().AccessToken);
-            Response resp = await Rest.DeleteAsync(url, headers,-1, true);
-            if (!resp.Successful)
+
+            // decode the access token
+            string decodedToken = JWT_Decoding(ServiceManager.GetService<LearningLayersOidcService>().AccessToken);
+            if (decodedToken == "")
             {
-                Debug.LogError(resp.ResponseCode + ": " + resp.ResponseBody);
+                Debug.LogError("Invalid Access Token for Decoding.");
                 return null;
             }
             else
             {
-                Requirement requirement = JsonUtility.FromJson<Requirement>(resp.ResponseBody);
-                return requirement;
+
+                // extract sub and preferred username information and encode for the header
+                string authentificationInfoInfo = GetBasicAuthentificationInfo(decodedToken);
+                byte[] authentificationInfoInfoBytes = Encoding.UTF8.GetBytes(authentificationInfoInfo);
+                string encodedAuthentificationInfo = Convert.ToBase64String(authentificationInfoInfoBytes);
+
+                Debug.Log(encodedAuthentificationInfo);
+
+                headers.Add("Authorization", "Basic " + encodedAuthentificationInfo);
+                headers.Add("access-token", ServiceManager.GetService<LearningLayersOidcService>().AccessToken);
+
+                Debug.Log(headers);
+                Response resp = await Rest.DeleteAsync(url, headers, -1, true);
+                if (!resp.Successful)
+                {
+                    Debug.LogError(resp.ResponseCode + ": " + resp.ResponseBody);
+                    return null;
+                }
+                else
+                {
+                    Requirement requirement = JsonUtility.FromJson<Requirement>(resp.ResponseBody);
+                    return requirement;
+                }
             }
+        }
+
+        /// <summary>
+        /// Decodes the access token using JWT decoding
+        /// </summary>
+        /// <param name="accessToken">The access token of the user</param>
+        /// <returns>The decoded access token</returns>
+        private static string JWT_Decoding(string accessToken)
+        {
+            string[] tokenParts = accessToken.Split('.');
+            if (tokenParts.Length > 2)
+            {
+                string decodedBody = tokenParts[1];
+                int paddingLength = 4 - decodedBody.Length % 4;
+                if (paddingLength < 4)
+                {
+                    decodedBody += new string('=', paddingLength);
+                }
+                byte[] bytes = System.Convert.FromBase64String(decodedBody);
+                string decodedToken = System.Text.ASCIIEncoding.ASCII.GetString(bytes);
+                return decodedToken;
+            }
+            return "";
+        }
+
+        /// <summary>
+        /// Extracts the subject and preferred username information from the decoded access token
+        /// </summary>
+        /// <param name="decodedToken">The access token which has been decoded using JWT</param>
+        /// <returns>A string containing the subject and preferred username</returns>
+        private static string GetBasicAuthentificationInfo(string decodedToken)
+        {
+            string[] elements = decodedToken.Split(',');
+            string sub = "";
+            string preferred_username = "";
+
+            for (int i = 0; i < elements.Length; i++)
+            {
+                if (elements[i].Contains("sub"))
+                {
+                    sub = elements[i].Split(':')[1];
+                    sub = sub.Substring(1, sub.Length - 2);
+                }
+                if (elements[i].Contains("preferred_username"))
+                {
+                    preferred_username = elements[i].Split(':')[1];
+                    preferred_username = preferred_username.Substring(1, preferred_username.Length - 2);
+                }
+            }
+
+            return preferred_username + ":" + sub;
+
         }
 
         /// <summary>
@@ -222,7 +323,7 @@ namespace Org.Requirements_Bazaar.API
         /// <param name="description">The description of the requirement</param>
         /// <param name="categories">Categories in the project</param>
         /// <returns>The resulting requirement as it was saved on the server</returns>
-        public static async Task<Requirement> CreateRequirement(int projectId, string name, string description, Category[] categories = null)
+        public static async Task<Requirement> CreateRequirement(int projectId, string name, string description, int[] categories = null)
         {
             string url = baseUrl + "requirements/";
 
@@ -230,7 +331,7 @@ namespace Org.Requirements_Bazaar.API
             if (categories == null)
             {
                 Project proj = await GetProject(projectId);
-                categories = new Category[1];
+                categories = new int[1];
                 categories[0] = await GetCategory(proj.DefaultCategoryId);
             }
 
@@ -244,17 +345,40 @@ namespace Org.Requirements_Bazaar.API
             {
                 Debug.Log("Service not null");
             }
-            headers.Add("Authorization", "Bearer " + ServiceManager.GetService<LearningLayersOidcService>().AccessToken);
-            Response resp = await Rest.PostAsync(url, json, headers, -1, true);
-            if (!resp.Successful)
+
+            // decode the access token
+            string decodedToken = JWT_Decoding(ServiceManager.GetService<LearningLayersOidcService>().AccessToken);
+            if (decodedToken == "")
             {
-                Debug.LogError(resp.ResponseCode + ": " + resp.ResponseBody);
+                Debug.LogError("Invalid Access Token for Decoding.");
                 return null;
             }
             else
             {
-                Requirement requirement = JsonUtility.FromJson<Requirement>(resp.ResponseBody);
-                return requirement;
+
+                // extract sub and preferred username information and encode for the header
+                string authentificationInfoInfo = GetBasicAuthentificationInfo(decodedToken);
+                byte[] authentificationInfoInfoBytes = Encoding.UTF8.GetBytes(authentificationInfoInfo);
+                string encodedAuthentificationInfo = Convert.ToBase64String(authentificationInfoInfoBytes);
+
+                Debug.Log(encodedAuthentificationInfo);
+
+                headers.Add("Authorization", "Basic " + encodedAuthentificationInfo);
+                headers.Add("access-token", ServiceManager.GetService<LearningLayersOidcService>().AccessToken);
+
+                Debug.Log(ServiceManager.GetService<LearningLayersOidcService>().AccessToken);
+
+                Response resp = await Rest.PostAsync(url, json, headers, -1, true);
+                if (!resp.Successful)
+                {
+                    Debug.LogError(resp.ResponseCode + ": " + resp.ResponseBody);
+                    return null;
+                }
+                else
+                {
+                    Requirement requirement = JsonUtility.FromJson<Requirement>(resp.ResponseBody);
+                    return requirement;
+                }
             }
         }
 
@@ -300,18 +424,40 @@ namespace Org.Requirements_Bazaar.API
             {
                 Debug.Log("Service not null");
             }
-            headers.Add("Authorization", "Bearer " + ServiceManager.GetService<LearningLayersOidcService>().AccessToken);
 
-            Response response = await Rest.PutAsync(url, json, headers, -1, true);
-            if (!response.Successful)
+            // decode the access token
+            string decodedToken = JWT_Decoding(ServiceManager.GetService<LearningLayersOidcService>().AccessToken);
+            if (decodedToken == "")
             {
-                Debug.LogError(response.ResponseCode + ": " + response.ResponseBody);
+                Debug.LogError("Invalid Access Token for Decoding.");
                 return null;
             }
             else
             {
-                Requirement updatedRequirement = JsonUtility.FromJson<Requirement>(response.ResponseBody);
-                return updatedRequirement;
+
+                // extract sub and preferred username information and encode for the header
+                string authentificationInfoInfo = GetBasicAuthentificationInfo(decodedToken);
+                byte[] authentificationInfoInfoBytes = Encoding.UTF8.GetBytes(authentificationInfoInfo);
+                string encodedAuthentificationInfo = Convert.ToBase64String(authentificationInfoInfoBytes);
+
+                Debug.Log(encodedAuthentificationInfo);
+
+                headers.Add("Authorization", "Basic " + encodedAuthentificationInfo);
+                headers.Add("access-token", ServiceManager.GetService<LearningLayersOidcService>().AccessToken);
+
+                Debug.Log(ServiceManager.GetService<LearningLayersOidcService>().AccessToken);
+
+                Response response = await Rest.PutAsync(url, json, headers, -1, true);
+                if (!response.Successful)
+                {
+                    Debug.LogError(response.ResponseCode + ": " + response.ResponseBody);
+                    return null;
+                }
+                else
+                {
+                    Requirement updatedRequirement = JsonUtility.FromJson<Requirement>(response.ResponseBody);
+                    return updatedRequirement;
+                }
             }
         }
 

--- a/Frontend/VIAProMa/Assets/Scripts/IssueEditing/RequirementBazaarAPI/RequirementsBazaarManager.cs
+++ b/Frontend/VIAProMa/Assets/Scripts/IssueEditing/RequirementBazaarAPI/RequirementsBazaarManager.cs
@@ -416,7 +416,7 @@ namespace Org.Requirements_Bazaar.API
             requirement.Description = newDescription;
 
 
-            string url = baseUrl + "requirements/" + requirement.Id;
+            string url = baseUrl + "requirements";
 
             // convert the requirement to a uploadable format (the statistic fields of the requirement are not recognized as input by the service)
             UploadableRequirement uploadableRequirement = requirement.ToUploadFormat();

--- a/Frontend/VIAProMa/Assets/Scripts/IssueEditing/RequirementBazaarAPI/RequirementsBazaarManager.cs
+++ b/Frontend/VIAProMa/Assets/Scripts/IssueEditing/RequirementBazaarAPI/RequirementsBazaarManager.cs
@@ -176,16 +176,20 @@ namespace Org.Requirements_Bazaar.API
                 byte[] authentificationInfoInfoBytes = Encoding.UTF8.GetBytes(authentificationInfoInfo);
                 string encodedAuthentificationInfo = Convert.ToBase64String(authentificationInfoInfoBytes);
 
-                Debug.Log(encodedAuthentificationInfo);
-
                 headers.Add("Authorization", "Basic " + encodedAuthentificationInfo);
                 headers.Add("access-token", ServiceManager.GetService<LearningLayersOidcService>().AccessToken);
 
-                Debug.Log(headers);
                 Response resp = await Rest.DeleteAsync(url, headers, -1, true);
                 if (!resp.Successful)
                 {
-                    Debug.LogError(resp.ResponseCode + ": " + resp.ResponseBody);
+                    if(resp.ResponseCode == 401)
+                    {
+                        Debug.LogError("You are not authorized to delete this requirement.");
+                    }
+                    else
+                    {
+                        Debug.LogError(resp.ResponseCode + ": " + resp.ResponseBody);
+                    }
                     return null;
                 }
                 else

--- a/Frontend/VIAProMa/Assets/Scripts/IssueEditing/RequirementBazaarAPI/RequirementsBazaarManager.cs
+++ b/Frontend/VIAProMa/Assets/Scripts/IssueEditing/RequirementBazaarAPI/RequirementsBazaarManager.cs
@@ -224,7 +224,6 @@ namespace Org.Requirements_Bazaar.API
                 Debug.LogError("Requirement not found");
                 return null;
             }
-            Debug.Log(requirementId);
             string url = baseUrl + "requirements/" + requirementId.ToString();
             Dictionary<string, string> headers = new Dictionary<string, string>();
             if(ServiceManager.GetService<LearningLayersOidcService>() != null)
@@ -247,12 +246,9 @@ namespace Org.Requirements_Bazaar.API
                 byte[] authentificationInfoInfoBytes = Encoding.UTF8.GetBytes(authentificationInfoInfo);
                 string encodedAuthentificationInfo = Convert.ToBase64String(authentificationInfoInfoBytes);
 
-                Debug.Log(encodedAuthentificationInfo);
-
                 headers.Add("Authorization", "Basic " + encodedAuthentificationInfo);
                 headers.Add("access-token", ServiceManager.GetService<LearningLayersOidcService>().AccessToken);
 
-                Debug.Log(headers);
                 Response resp = await Rest.DeleteAsync(url, headers, -1, true);
                 if (!resp.Successful)
                 {
@@ -365,12 +361,8 @@ namespace Org.Requirements_Bazaar.API
                 byte[] authentificationInfoInfoBytes = Encoding.UTF8.GetBytes(authentificationInfoInfo);
                 string encodedAuthentificationInfo = Convert.ToBase64String(authentificationInfoInfoBytes);
 
-                Debug.Log(encodedAuthentificationInfo);
-
                 headers.Add("Authorization", "Basic " + encodedAuthentificationInfo);
                 headers.Add("access-token", ServiceManager.GetService<LearningLayersOidcService>().AccessToken);
-
-                Debug.Log(ServiceManager.GetService<LearningLayersOidcService>().AccessToken);
 
                 Response resp = await Rest.PostAsync(url, json, headers, -1, true);
                 if (!resp.Successful)
@@ -444,12 +436,8 @@ namespace Org.Requirements_Bazaar.API
                 byte[] authentificationInfoInfoBytes = Encoding.UTF8.GetBytes(authentificationInfoInfo);
                 string encodedAuthentificationInfo = Convert.ToBase64String(authentificationInfoInfoBytes);
 
-                Debug.Log(encodedAuthentificationInfo);
-
                 headers.Add("Authorization", "Basic " + encodedAuthentificationInfo);
                 headers.Add("access-token", ServiceManager.GetService<LearningLayersOidcService>().AccessToken);
-
-                Debug.Log(ServiceManager.GetService<LearningLayersOidcService>().AccessToken);
 
                 Response response = await Rest.PutAsync(url, json, headers, -1, true);
                 if (!response.Successful)
@@ -473,7 +461,7 @@ namespace Org.Requirements_Bazaar.API
         /// <returns>The updated requirement</returns>
         public static async Task<Requirement> UpdateRequirement(Requirement toUpdate)
         {
-            string url = baseUrl + "requirements/" + toUpdate.Id;
+            string url = baseUrl + "requirements";
 
             // convert the requirement to a uploadable format (the statistic fields of the requirement are not recognized as input by the service)
             UploadableRequirement uploadableRequirement = toUpdate.ToUploadFormat();

--- a/Frontend/VIAProMa/Assets/Scripts/IssueEditing/RequirementBazaarAPI/RequirementsBazaarManager.cs
+++ b/Frontend/VIAProMa/Assets/Scripts/IssueEditing/RequirementBazaarAPI/RequirementsBazaarManager.cs
@@ -179,23 +179,30 @@ namespace Org.Requirements_Bazaar.API
                 headers.Add("Authorization", "Basic " + encodedAuthentificationInfo);
                 headers.Add("access-token", ServiceManager.GetService<LearningLayersOidcService>().AccessToken);
 
-                Response resp = await Rest.DeleteAsync(url, headers, -1, true);
-                if (!resp.Successful)
+                try
                 {
-                    if(resp.ResponseCode == 401)
+                    Response resp = await Rest.DeleteAsync(url, headers, -1, true);
+                    if (!resp.Successful)
                     {
-                        Debug.LogError("You are not authorized to delete this requirement.");
+                        if (resp.ResponseCode == 401)
+                        {
+                            Debug.LogError("You are not authorized to delete this requirement.");
+                        }
+                        else
+                        {
+                            Debug.LogError(resp.ResponseCode + ": " + resp.ResponseBody);
+                        }
+                        return null;
                     }
                     else
                     {
-                        Debug.LogError(resp.ResponseCode + ": " + resp.ResponseBody);
+                        Requirement requirement = JsonUtility.FromJson<Requirement>(resp.ResponseBody);
+                        return requirement;
                     }
-                    return null;
                 }
-                else
+                catch (ArgumentNullException)
                 {
-                    Requirement requirement = JsonUtility.FromJson<Requirement>(resp.ResponseBody);
-                    return requirement;
+                    return null;
                 }
             }
         }

--- a/Frontend/VIAProMa/Assets/Scripts/IssueEditing/RequirementBazaarAPI/UploadableRequirement.cs
+++ b/Frontend/VIAProMa/Assets/Scripts/IssueEditing/RequirementBazaarAPI/UploadableRequirement.cs
@@ -14,17 +14,17 @@ namespace Org.Requirements_Bazaar.Serialization
     public class UploadableRequirement
     {
         [SerializeField] private int id;
-        [SerializeField] private int projectId;
         [SerializeField] private string name;
         [SerializeField] private string description;
-        [SerializeField] private Category[] categories;
+        [SerializeField] private int projectId;
+        [SerializeField] private int[] categories;
 
-        public UploadableRequirement(string name, string description, int projectId, Category[] categories)
+        public UploadableRequirement(string name, string description, int projectId, int[] categories)
             : this(0, name, description, projectId, categories)
         {
         }
 
-        public UploadableRequirement(int id, string name, string description, int projectId, Category[] categories)
+        public UploadableRequirement(int id, string name, string description, int projectId, int[] categories)
         {
             this.id = id;
             this.name = name;
@@ -100,7 +100,7 @@ namespace Org.Requirements_Bazaar.Serialization
         /// An array of categories to which the requirement belongs
         /// If it is null or has a length of 0, the requirement will be assigned to the default category of the project
         /// </summary>
-        public Category[] Categories
+        public int[] Categories
         {
             get
             {


### PR DESCRIPTION
This branch contains the new authorization required for RequirementsBazaar containing the de- and encoding of the newly necessary preferred_username and sub. Thus all WebRequest are now using the correct authorization. Furthermore, this branch fixes some issues with creating requirements such as now being able to create requirements even if no category was selected and fixing the creation of requirements in general by reworking the categories to be integers to conform to the new RequirementsBazaar format. The deletion of requirements also works now with the new authorization however an error in the Microsoft Mixed Reality Toolkit prevents the issue shelf from automatically updating itself. Closes #457 Closes #412 