### PR TITLE
Changed MRTK to i5 Webrequests

### DIFF
--- a/Frontend/VIAProMa/Assets/GithubCCD.asset
+++ b/Frontend/VIAProMa/Assets/GithubCCD.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bc4510c32e24e7f4392148cb1e762650, type: 3}
+  m_Name: GithubCCD
+  m_EditorClassIdentifier: 
+  clientData:
+    clientId: dc4cb673112ce791bee1
+    clientSecret: 079c93e445531e86d0b09192924ccfa82cffaa0b

--- a/Frontend/VIAProMa/Assets/GithubCCD.asset.meta
+++ b/Frontend/VIAProMa/Assets/GithubCCD.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7773683308be9694eb2f5d2df5098f88
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Frontend/VIAProMa/Assets/Prefabs/Shelves/Resources/IssueShelf.prefab
+++ b/Frontend/VIAProMa/Assets/Prefabs/Shelves/Resources/IssueShelf.prefab
@@ -9899,7 +9899,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7e4872dd45210c84bb1134b01b4b6c33, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  clientDataObject: {fileID: 11400000, guid: 17933bb104c1395408420ed026a401ed, type: 2}
+  clientDataObject: {fileID: 11400000, guid: 7773683308be9694eb2f5d2df5098f88, type: 2}
   loginCaption: {fileID: 1009365461409116616}
   statusCaption: {fileID: 828242988404845599}
   statusLed: {fileID: 1009626218954954769}
@@ -10921,7 +10921,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c85daea7479c8e442b56bf859332d0de, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  clientDataObject: {fileID: 11400000, guid: fb2ae7f2504b7c7429507e37671fe103, type: 2}
+  clientDataObject: {fileID: 11400000, guid: c77d0f272364d424b986ca69f3b29300, type: 2}
   loginCaption: {fileID: 6365370226358055450}
   statusCaption: {fileID: 8542734968993604344}
   statusLed: {fileID: 2785659790907189970}

--- a/Frontend/VIAProMa/Assets/ReqBazCCD.asset
+++ b/Frontend/VIAProMa/Assets/ReqBazCCD.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bc4510c32e24e7f4392148cb1e762650, type: 3}
+  m_Name: ReqBazCCD
+  m_EditorClassIdentifier: 
+  clientData:
+    clientId: cf612eb0-469d-49e1-a78c-6c2d873016d4
+    clientSecret: AJP67g2V0MvtZeWfMKA3Z5hkTEtgy5Nrr-5C6saOMfnf1UiEvv2tCFJesCJ_Vvk4YpNpdfh26h3zYlxY99PoRys

--- a/Frontend/VIAProMa/Assets/ReqBazCCD.asset.meta
+++ b/Frontend/VIAProMa/Assets/ReqBazCCD.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c77d0f272364d424b986ca69f3b29300
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Frontend/VIAProMa/Assets/Scenes/MainScene.unity
+++ b/Frontend/VIAProMa/Assets/Scenes/MainScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44402242, g: 0.49316543, b: 0.5722324, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -3148,9 +3148,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 118d10d69a3818346be0c79a169265a7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  learningLayersClientData: {fileID: 11400000, guid: fb2ae7f2504b7c7429507e37671fe103,
+  learningLayersClientData: {fileID: 11400000, guid: c77d0f272364d424b986ca69f3b29300,
     type: 2}
-  gitHubClientData: {fileID: 11400000, guid: 17933bb104c1395408420ed026a401ed, type: 2}
+  gitHubClientData: {fileID: 11400000, guid: 7773683308be9694eb2f5d2df5098f88, type: 2}
 --- !u!4 &926572256
 Transform:
   m_ObjectHideFlags: 0
@@ -3409,6 +3409,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 177bddf229f8d8445a70c0652f03b7df, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  DisconnectAfterKeepAlive: 0
   KeepAliveInBackground: 60000
   ApplyDontDestroyOnLoad: 1
 --- !u!4 &1452304941

--- a/Frontend/VIAProMa/Assets/Scripts/IssueEditing/RequirementBazaarAPI/RequirementsBazaarManager.cs
+++ b/Frontend/VIAProMa/Assets/Scripts/IssueEditing/RequirementBazaarAPI/RequirementsBazaarManager.cs
@@ -11,6 +11,7 @@ using UnityEngine;
 using UnityEngine.Networking;
 using i5.Toolkit.Core.OpenIDConnectClient;
 using i5.Toolkit.Core.ServiceCore;
+using i5.Toolkit.Core.Utilities;
 using i5.VIAProMa.Login;
 using System.Text;
 
@@ -19,6 +20,8 @@ namespace Org.Requirements_Bazaar.API
 
     public static class RequirementsBazaarManager
     {
+        public static IRestConnector RestConnector = new UnityWebRequestRestConnector();
+        public static IJsonSerializer JsonSerializer = new JsonUtilityAdapter();
         private const string baseUrl = "https://requirements-bazaar.org/bazaar/";
 
         /// <summary>
@@ -30,16 +33,15 @@ namespace Org.Requirements_Bazaar.API
         {
             string url = baseUrl + "projects/" + projectId.ToString();
 
-            Response response = await Rest.GetAsync(url, null, -1, null, true);
-            string responseBody = await response.GetResponseBody();
+            WebResponse<string> response = await RestConnector.GetAsync(url, null);
             if (!response.Successful)
             {
-                Debug.LogError(responseBody);
+                Debug.LogError(response.Content);
                 return null;
             }
             else
             {
-                Project project = JsonUtility.FromJson<Project>(responseBody);
+                Project project = JsonSerializer.FromJson<Project>(response.Content);
                 return project;
             }
         }
@@ -67,16 +69,15 @@ namespace Org.Requirements_Bazaar.API
                 url += "&search=" + searchFilter;
             }
 
-            Response response = await Rest.GetAsync(url, null, -1, null, true);
-            string responseBody = await response.GetResponseBody();
+            WebResponse<string> response = await RestConnector.GetAsync(url, null);
             if (!response.Successful)
             {
-                Debug.LogError(responseBody);
+                Debug.LogError(response.Content);
                 return null;
             }
             else
             {
-                string json = JsonHelper.EncapsulateInWrapper(responseBody);
+                string json = JsonHelper.EncapsulateInWrapper(response.Content);
                 int[] categoryList = JsonHelper.FromJson<int>(json);
                 return categoryList;
             }
@@ -111,16 +112,15 @@ namespace Org.Requirements_Bazaar.API
                 url += "&sort=" + sortMode.ToString().ToLower();
             }
 
-            Response response = await Rest.GetAsync(url, null, -1, null, true);
-            string responseBody = await response.GetResponseBody();
+            WebResponse<string> response = await RestConnector.GetAsync(url, null);
             if (!response.Successful)
             {
-                Debug.LogError(responseBody);
+                Debug.LogError(response.Content);
                 return null;
             }
             else
             {
-                string json = JsonHelper.EncapsulateInWrapper(responseBody);
+                string json = JsonHelper.EncapsulateInWrapper(response.Content);
                 Requirement[] requirements = JsonHelper.FromJson<Requirement>(json);
                 return requirements;
             }
@@ -165,8 +165,7 @@ namespace Org.Requirements_Bazaar.API
         {
             string url = baseUrl + "categories/" + categoryId.ToString();
 
-            Response response = await Rest.GetAsync(url, null, -1, null, true);
-            string responseBody = await response.GetResponseBody();
+            WebResponse<string> response = await RestConnector.GetAsync(url, null);
 
             if (!response.Successful)
             {
@@ -176,7 +175,7 @@ namespace Org.Requirements_Bazaar.API
             }
             else
             {
-                int category = JsonUtility.FromJson<int>(responseBody);
+                int category = JsonUtility.FromJson<int>(response.Content);
                 return category;
             }
         }
@@ -215,23 +214,22 @@ namespace Org.Requirements_Bazaar.API
 
                 try
                 {
-                    Response resp = await Rest.DeleteAsync(url, headers, -1, true);
-                    string responseBody = await resp.GetResponseBody();
+                    WebResponse<string> resp = await RestConnector.DeleteAsync(url, headers);
                     if (!resp.Successful)
                     {
-                        if (resp.ResponseCode == 401)
+                        if (resp.Code == 401)
                         {
                             Debug.LogError("You are not authorized to delete this requirement.");
                         }
                         else
                         {
-                            Debug.LogError(resp.ResponseCode + ": " + responseBody);
+                            Debug.LogError(resp.Code + ": " + resp.Content);
                         }
                         return null;
                     }
                     else
                     {
-                        Requirement requirement = JsonUtility.FromJson<Requirement>(responseBody);
+                        Requirement requirement = JsonSerializer.FromJson<Requirement>(resp.Content);
                         return requirement;
                     }
                 }
@@ -291,16 +289,15 @@ namespace Org.Requirements_Bazaar.API
                 headers.Add("Authorization", "Basic " + encodedAuthentificationInfo);
                 headers.Add("access-token", ServiceManager.GetService<LearningLayersOidcService>().AccessToken);
 
-                Response resp = await Rest.DeleteAsync(url, headers, -1, true);
-                string responseBody = await resp.GetResponseBody();
+                WebResponse<string> resp = await RestConnector.DeleteAsync(url, headers);
                 if (!resp.Successful)
                 {
-                    Debug.LogError(resp.ResponseCode + ": " + responseBody);
+                    Debug.LogError(resp.Code + ": " + resp.Content);
                     return null;
                 }
                 else
                 {
-                    Requirement requirement = JsonUtility.FromJson<Requirement>(responseBody);
+                    Requirement requirement = JsonSerializer.FromJson<Requirement>(resp.Content);
                     return requirement;
                 }
             }
@@ -407,16 +404,15 @@ namespace Org.Requirements_Bazaar.API
                 headers.Add("Authorization", "Basic " + encodedAuthentificationInfo);
                 headers.Add("access-token", ServiceManager.GetService<LearningLayersOidcService>().AccessToken);
 
-                Response resp = await Rest.PostAsync(url, json, headers, -1, true);
-                string responseBody = await resp.GetResponseBody();
+                WebResponse<string> resp = await RestConnector.PostAsync(url, json, headers);
                 if (!resp.Successful)
                 {
-                    Debug.LogError(resp.ResponseCode + ": " + responseBody);
+                    Debug.LogError(resp.Code + ": " + resp.Content);
                     return null;
                 }
                 else
                 {
-                    Requirement requirement = JsonUtility.FromJson<Requirement>(responseBody);
+                    Requirement requirement = JsonSerializer.FromJson<Requirement>(resp.Content);
                     return requirement;
                 }
             }
@@ -485,16 +481,15 @@ namespace Org.Requirements_Bazaar.API
                 headers.Add("Authorization", "Basic " + encodedAuthentificationInfo);
                 headers.Add("access-token", ServiceManager.GetService<LearningLayersOidcService>().AccessToken);
 
-                Response response = await Rest.PutAsync(url, json, headers, -1, true);
-                string responseBody = await response.GetResponseBody();
+                WebResponse<string> response = await RestConnector.PutAsync(url, json, headers);
                 if (!response.Successful)
                 {
-                    Debug.LogError(response.ResponseCode + ": " + responseBody);
+                    Debug.LogError(response.Code + ": " + response.Content);
                     return null;
                 }
                 else
                 {
-                    Requirement updatedRequirement = JsonUtility.FromJson<Requirement>(responseBody);
+                    Requirement updatedRequirement = JsonSerializer.FromJson<Requirement>(response.Content);
                     return updatedRequirement;
                 }
             }
@@ -515,16 +510,15 @@ namespace Org.Requirements_Bazaar.API
 
             string json = JsonUtility.ToJson(uploadableRequirement);
 
-            Response response = await Rest.PutAsync(url, json, null, -1, true);
-            string responseBody = await response.GetResponseBody();
+            WebResponse<string> response = await RestConnector.PutAsync(url, json);
             if (!response.Successful)
             {
-                Debug.LogError(response.ResponseCode + ": " + responseBody);
+                Debug.LogError(response.Code + ": " + response.Content);
                 return null;
             }
             else
             {
-                Requirement requirement = JsonUtility.FromJson<Requirement>(responseBody);
+                Requirement requirement = JsonSerializer.FromJson<Requirement>(response.Content);
                 return requirement;
             }
         }

--- a/Frontend/VIAProMa/Assets/Scripts/WebConnection/GitHub.cs
+++ b/Frontend/VIAProMa/Assets/Scripts/WebConnection/GitHub.cs
@@ -4,6 +4,7 @@ using i5.VIAProMa.Utilities;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using System.Threading.Tasks;
 using UnityEngine;
+using i5.Toolkit.Core.Utilities;
 
 namespace i5.VIAProMa.WebConnection
 {
@@ -13,6 +14,10 @@ namespace i5.VIAProMa.WebConnection
     /// </summary>
     public static class GitHub
     {
+
+        public static IRestConnector RestConnector = new UnityWebRequestRestConnector();
+        public static IJsonSerializer JsonSerializer = new JsonUtilityAdapter();
+
         /// <summary>
         /// Gets the issues of a GitHub repository on the given page
         /// </summary>
@@ -23,22 +28,16 @@ namespace i5.VIAProMa.WebConnection
         /// <returns>An array of issues in the repository; contained in an APIResult object</returns>
         public static async Task<ApiResult<Issue[]>> GetIssuesInRepository(string owner, string repositoryName, int page, int itemsPerPage)
         {
-            Response resp = await Rest.GetAsync(
-                ConnectionManager.Instance.BackendAPIBaseURL + "gitHub/repos/" + owner + "/" + repositoryName + "/issues?page=" + page + "&per_page=" + itemsPerPage,
-                null,
-                -1,
-                null,
-                true);
-            ConnectionManager.Instance.CheckStatusCode(resp.ResponseCode);
-            string responseBody = await resp.GetResponseBody();
+            WebResponse<string> resp = await RestConnector.GetAsync(ConnectionManager.Instance.BackendAPIBaseURL + "gitHub/repos/" + owner + "/" + repositoryName + "/issues?page=" + page + "&per_page=" + itemsPerPage, null);
+            ConnectionManager.Instance.CheckStatusCode(resp.Code);
             if (!resp.Successful)
             {
-                Debug.LogError(resp.ResponseCode + ": " + responseBody);
-                return new ApiResult<Issue[]>(resp.ResponseCode, responseBody);
+                Debug.LogError(resp.Code + ": " + resp.Content);
+                return new ApiResult<Issue[]>(resp.Code, resp.Content);
             }
             else
             {
-                Issue[] issues = JsonArrayUtility.FromJson<Issue>(responseBody);
+                Issue[] issues = Utilities.JsonArrayUtility.FromJson<Issue>(resp.Content);
                 foreach (Issue issue in issues)
                 {
                     IssueCache.AddIssue(issue);
@@ -61,22 +60,16 @@ namespace i5.VIAProMa.WebConnection
                 return new ApiResult<Issue>(cached);
             }
 
-            Response resp = await Rest.GetAsync(
-                ConnectionManager.Instance.BackendAPIBaseURL + "gitHub/repositories/" + repositoryId + "/issues/" + issueNumber,
-                null,
-                -1,
-                null,
-                true);
-            ConnectionManager.Instance.CheckStatusCode(resp.ResponseCode);
-            string responseBody = await resp.GetResponseBody();
+            WebResponse<string> resp = await RestConnector.GetAsync(ConnectionManager.Instance.BackendAPIBaseURL + "gitHub/repositories/" + repositoryId + "/issues/" + issueNumber, null);
+            ConnectionManager.Instance.CheckStatusCode(resp.Code);
             if (!resp.Successful)
             {
-                Debug.LogError(resp.ResponseCode + ": " + responseBody);
-                return new ApiResult<Issue>(resp.ResponseCode, responseBody);
+                Debug.LogError(resp.Code + ": " + resp.Content);
+                return new ApiResult<Issue>(resp.Code, resp.Content);
             }
             else
             {
-                Issue issue = JsonUtility.FromJson<Issue>(responseBody);
+                Issue issue = JsonSerializer.FromJson<Issue>(resp.Content);
                 IssueCache.AddIssue(issue);
                 return new ApiResult<Issue>(issue);
             }
@@ -84,22 +77,16 @@ namespace i5.VIAProMa.WebConnection
 
         public static async Task<ApiResult<PunchCardEntry[]>> GetGitHubPunchCard(string owner, string repository)
         {
-            Response resp = await Rest.GetAsync(
-                ConnectionManager.Instance.BackendAPIBaseURL + "githubPunchCard/" + owner + "/" + repository,
-                null,
-                -1,
-                null,
-                true);
-            ConnectionManager.Instance.CheckStatusCode(resp.ResponseCode);
-            string responseBody = await resp.GetResponseBody();
+            WebResponse<string> resp = await RestConnector.GetAsync(ConnectionManager.Instance.BackendAPIBaseURL + "githubPunchCard/" + owner + "/" + repository, null);
+            ConnectionManager.Instance.CheckStatusCode(resp.Code);
             if (!resp.Successful)
             {
-                Debug.LogError(resp.ResponseCode + ": " + responseBody);
-                return new ApiResult<PunchCardEntry[]>(resp.ResponseCode, responseBody);
+                Debug.LogError(resp.Code + ": " + resp.Content);
+                return new ApiResult<PunchCardEntry[]>(resp.Code, resp.Content);
             }
             else
             {
-                PunchCardEntry[] gitHubPunchCard = JsonArrayUtility.FromJson<PunchCardEntry>(responseBody);
+                PunchCardEntry[] gitHubPunchCard = Utilities.JsonArrayUtility.FromJson<PunchCardEntry>(resp.Content);
                 return new ApiResult<PunchCardEntry[]>(gitHubPunchCard);
             }
         }

--- a/Frontend/VIAProMa/Assets/Scripts/WebConnection/NetworkedStringManager.cs
+++ b/Frontend/VIAProMa/Assets/Scripts/WebConnection/NetworkedStringManager.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using UnityEngine;
+using i5.Toolkit.Core.Utilities;
 
 namespace i5.VIAProMa.WebConnection
 {
@@ -12,6 +13,8 @@ namespace i5.VIAProMa.WebConnection
     /// </summary>
     public static class NetworkedStringManager
     {
+        public static IRestConnector RestConnector = new UnityWebRequestRestConnector();
+        public static IJsonSerializer JsonSerializer = new JsonUtilityAdapter();
         private const string serviceEndpoint = "networkedStrings";
 
         /// <summary>
@@ -29,20 +32,14 @@ namespace i5.VIAProMa.WebConnection
             Dictionary<string, string> headers = new Dictionary<string, string>();
             headers.Add("Content-Type", "text/plain"); // overwrite the content type
             headers.Add("Accept", "text/plain"); // overwrite the accept type
-            Response resp = await Rest.PostAsync(
-                ConnectionManager.Instance.BackendAPIBaseURL + serviceEndpoint,
-                text,
-                headers,
-                -1,
-                true);
-            string responseBody = await resp.GetResponseBody();
+            WebResponse<string> resp = await RestConnector.PostAsync(ConnectionManager.Instance.BackendAPIBaseURL + serviceEndpoint, text, headers);
             if (resp.Successful)
              {
-                 return short.Parse(responseBody);
+                 return short.Parse(resp.Content);
              }
              else
              {
-                 Debug.LogError(responseBody);
+                 Debug.LogError(resp.Content);
                  return -1;
              }
         }
@@ -59,20 +56,14 @@ namespace i5.VIAProMa.WebConnection
                 return "";
             }
 
-            Response resp = await Rest.GetAsync(
-                ConnectionManager.Instance.BackendAPIBaseURL + serviceEndpoint + "/" + id,
-                null,
-                -1,
-                null,
-                true);
-            string responseBody = await resp.GetResponseBody();
+            WebResponse<string> resp = await RestConnector.GetAsync(ConnectionManager.Instance.BackendAPIBaseURL + serviceEndpoint + "/" + id, null);
             if (resp.Successful)
             {
-                return responseBody;
+                return resp.Content;
             }
             else
             {
-                Debug.LogError(responseBody);
+                Debug.LogError(resp.Content);
                 return "";
             }
         }

--- a/Frontend/VIAProMa/Assets/Scripts/WebConnection/RequirementsBazaar.cs
+++ b/Frontend/VIAProMa/Assets/Scripts/WebConnection/RequirementsBazaar.cs
@@ -3,6 +3,7 @@ using i5.VIAProMa.DataModel.API;
 using i5.VIAProMa.DataModel.ReqBaz;
 using i5.VIAProMa.Login;
 using i5.VIAProMa.Utilities;
+using i5.Toolkit.Core.Utilities;
 using Microsoft.MixedReality.Toolkit.Utilities;
 using Org.Requirements_Bazaar.API;
 using System;
@@ -18,31 +19,29 @@ namespace i5.VIAProMa.WebConnection
     /// </summary>
     public static class RequirementsBazaar
     {
+
+        public static IRestConnector RestConnector = new UnityWebRequestRestConnector();
+        public static IJsonSerializer JsonSerializer = new JsonUtilityAdapter();
         /// <summary>
         /// Gets the available projects of the Requirements Bazaar
         /// </summary>
         /// <returns></returns>
         public static async Task<ApiResult<Project[]>> GetProjects()
         {
+            RestConnector = new UnityWebRequestRestConnector();
             Debug.Log("Requirements Baazar: GetProjects");
             if (ServiceManager.GetService<LearningLayersOidcService>().AccessToken == null || ServiceManager.GetService<LearningLayersOidcService>().AccessToken == "")
             {
-                Response resp = await Rest.GetAsync(
-                    ConnectionManager.Instance.BackendAPIBaseURL + "requirementsBazaar/projects",
-                    null,
-                    -1,
-                    null,
-                    true);
-                ConnectionManager.Instance.CheckStatusCode(resp.ResponseCode);
-                string responseBody = await resp.GetResponseBody();
+                WebResponse<string> resp = await RestConnector.GetAsync(ConnectionManager.Instance.BackendAPIBaseURL + "requirementsBazaar/projects", null);
+                ConnectionManager.Instance.CheckStatusCode(resp.Code);
                 if (!resp.Successful)
                 {
-                    Debug.LogError(resp.ResponseCode + ": " + responseBody);
-                    return new ApiResult<Project[]>(resp.ResponseCode, responseBody);
+                    Debug.LogError(resp.Code + ": " + resp.Content);
+                    return new ApiResult<Project[]>(resp.Code, resp.Content);
                 }
                 else
                 {
-                    Project[] projects = JsonArrayUtility.FromJson<Project>(responseBody);
+                    Project[] projects = Utilities.JsonArrayUtility.FromJson<Project>(resp.Content);
                     List<Project> visibleProjects = new List<Project>();
                     foreach (Project project in projects)
                     {
@@ -79,24 +78,17 @@ namespace i5.VIAProMa.WebConnection
                     headers.Add("access-token", ServiceManager.GetService<LearningLayersOidcService>().AccessToken);
                     try
                     {
-                        Response resp = await Rest.GetAsync(
-                    //ConnectionManager.Instance.BackendAPIBaseURL + "requirementsBazaar/projects/?state=all&per_page=500",
-                    "https://requirements-bazaar.org/bazaar/projects/?state=all&per_page=500",
-                    headers,
-                    -1,
-                    null,
-                    true);
-                        ConnectionManager.Instance.CheckStatusCode(resp.ResponseCode);
-                        string responseBody = await resp.GetResponseBody();
+                        WebResponse<string> resp = await RestConnector.GetAsync("https://requirements-bazaar.org/bazaar/projects/?state=all&per_page=500", headers);
+                        ConnectionManager.Instance.CheckStatusCode(resp.Code);
                         if (!resp.Successful)
                         {
-                            Debug.LogError(resp.ResponseCode + ": " + responseBody);
-                            return new ApiResult<Project[]>(resp.ResponseCode, responseBody);
+                            Debug.LogError(resp.Code + ": " + resp.Content);
+                            return new ApiResult<Project[]>(resp.Code, resp.Content);
                         }
                         else
                         {
-                            responseBody = "{\"array\":" + responseBody + "}";
-                            Project[] projects = JsonArrayUtility.FromJson<Project>(responseBody);
+                            string responseBody = "{\"array\":" + resp.Content + "}";
+                            Project[] projects = Utilities.JsonArrayUtility.FromJson<Project>(responseBody);
                             return new ApiResult<Project[]>(projects);
                         }
                     }
@@ -118,22 +110,16 @@ namespace i5.VIAProMa.WebConnection
         {
             if (ServiceManager.GetService<LearningLayersOidcService>().AccessToken == null || ServiceManager.GetService<LearningLayersOidcService>().AccessToken == "")
             {
-                Response resp = await Rest.GetAsync(
-                ConnectionManager.Instance.BackendAPIBaseURL + "requirementsBazaar/projects/" + projectId + "/categories",
-                null,
-                -1,
-                null,
-                true);
-                ConnectionManager.Instance.CheckStatusCode(resp.ResponseCode);
-                string responseBody = await resp.GetResponseBody();
+                WebResponse<string> resp = await RestConnector.GetAsync(ConnectionManager.Instance.BackendAPIBaseURL + "requirementsBazaar/projects/" + projectId + "/categories", null);
+                ConnectionManager.Instance.CheckStatusCode(resp.Code);
                 if (!resp.Successful)
                 {
-                    Debug.LogError(resp.ResponseCode + ": " + responseBody);
-                    return new ApiResult<Category[]>(resp.ResponseCode, responseBody);
+                    Debug.LogError(resp.Code + ": " + resp.Content);
+                    return new ApiResult<Category[]>(resp.Code, resp.Content);
                 }
                 else
                 {
-                    Category[] categories = JsonArrayUtility.FromJson<Category>(responseBody);
+                    Category[] categories = Utilities.JsonArrayUtility.FromJson<Category>(resp.Content);
                     return new ApiResult<Category[]>(categories);
                 }
             }
@@ -165,24 +151,17 @@ namespace i5.VIAProMa.WebConnection
 
                     try
                     {
-                        Response resp = await Rest.GetAsync(
-                //ConnectionManager.Instance.BackendAPIBaseURL + "requirementsBazaar/projects/" + projectId + "/categories",
-                "https://requirements-bazaar.org/bazaar/projects/" + projectId + "/categories?state=all&per_page=500",
-                headers,
-                -1,
-                null,
-                true);
-                        ConnectionManager.Instance.CheckStatusCode(resp.ResponseCode);
-                        string responseBody = await resp.GetResponseBody();
-                        responseBody = "{\"array\":" + responseBody + "}";
+                        WebResponse<string> resp = await RestConnector.GetAsync("https://requirements-bazaar.org/bazaar/projects/" + projectId + "/categories?state=all&per_page=500", headers);
+                        ConnectionManager.Instance.CheckStatusCode(resp.Code);
+                        string responseBody = "{\"array\":" + resp.Content + "}";
                         if (!resp.Successful)
                         {
-                            Debug.LogError(resp.ResponseCode + ": " + responseBody);
-                            return new ApiResult<Category[]>(resp.ResponseCode, responseBody);
+                            Debug.LogError(resp.Code + ": " + responseBody);
+                            return new ApiResult<Category[]>(resp.Code, responseBody);
                         }
                         else
                         {
-                            Category[] categories = JsonArrayUtility.FromJson<Category>(responseBody);
+                            Category[] categories = Utilities.JsonArrayUtility.FromJson<Category>(responseBody);
                             return new ApiResult<Category[]>(categories);
                         }
                     }
@@ -207,22 +186,16 @@ namespace i5.VIAProMa.WebConnection
                 return new ApiResult<Issue>(cached);
             }
 
-            Response resp = await Rest.GetAsync(
-                ConnectionManager.Instance.BackendAPIBaseURL + "requirementsBazaar/requirements/" + requirementId,
-                null,
-                -1,
-                null,
-                true);
-            ConnectionManager.Instance.CheckStatusCode(resp.ResponseCode);
-            string responseBody = await resp.GetResponseBody();
+            WebResponse<string> resp = await RestConnector.GetAsync(ConnectionManager.Instance.BackendAPIBaseURL + "requirementsBazaar/requirements/" + requirementId, null);
+            ConnectionManager.Instance.CheckStatusCode(resp.Code);
             if (!resp.Successful)
             {
-                Debug.LogError(resp.ResponseCode + ": " + responseBody);
-                return new ApiResult<Issue>(resp.ResponseCode, responseBody);
+                Debug.LogError(resp.Code + ": " + resp.Content);
+                return new ApiResult<Issue>(resp.Code, resp.Content);
             }
             else
             {
-                Issue issue = JsonUtility.FromJson<Issue>(responseBody);
+                Issue issue = JsonSerializer.FromJson<Issue>(resp.Content);
                 IssueCache.AddIssue(issue);
                 return new ApiResult<Issue>(issue);
             }
@@ -259,17 +232,16 @@ namespace i5.VIAProMa.WebConnection
 
             if (ServiceManager.GetService<LearningLayersOidcService>().AccessToken == null || ServiceManager.GetService<LearningLayersOidcService>().AccessToken == "")
             {
-                Response resp = await Rest.GetAsync(path, null, -1, null, true);
-                ConnectionManager.Instance.CheckStatusCode(resp.ResponseCode);
-                string responseBody = await resp.GetResponseBody();
+                WebResponse<string> resp = await RestConnector.GetAsync(path, null);
+                ConnectionManager.Instance.CheckStatusCode(resp.Code);
                 if (!resp.Successful)
                 {
-                    Debug.LogError(resp.ResponseCode + ": " + responseBody);
-                    return new ApiResult<Issue[]>(resp.ResponseCode, responseBody);
+                    Debug.LogError(resp.Code + ": " + resp.Content);
+                    return new ApiResult<Issue[]>(resp.Code, resp.Content);
                 }
                 else
                 {
-                    Issue[] requirements = JsonArrayUtility.FromJson<Issue>(responseBody);
+                    Issue[] requirements = Utilities.JsonArrayUtility.FromJson<Issue>(resp.Content);
                     // add to cache
                     foreach (Issue req in requirements)
                     {
@@ -307,18 +279,17 @@ namespace i5.VIAProMa.WebConnection
                     try
                     {
                         path = "https://requirements-bazaar.org/bazaar/projects/" + projectId + "/requirements?page=" + page + "&per_page=" + itemsPerPage;
-                        Response resp = await Rest.GetAsync(path, headers, -1, null, true);
-                        ConnectionManager.Instance.CheckStatusCode(resp.ResponseCode);
-                        string responseBody = await resp.GetResponseBody();
-                        responseBody = "{\"array\":" + responseBody + "}";
+                        WebResponse<string> resp = await RestConnector.GetAsync(path, headers);
+                        ConnectionManager.Instance.CheckStatusCode(resp.Code);
+                        string responseBody = "{\"array\":" + resp.Content + "}";
                         if (!resp.Successful)
                         {
-                            Debug.LogError(resp.ResponseCode + ": " + responseBody);
-                            return new ApiResult<Issue[]>(resp.ResponseCode, responseBody);
+                            Debug.LogError(resp.Code + ": " + responseBody);
+                            return new ApiResult<Issue[]>(resp.Code, responseBody);
                         }
                         else
                         {
-                            Issue[] requirements = JsonArrayUtility.FromJson<Issue>(responseBody);
+                            Issue[] requirements = Utilities.JsonArrayUtility.FromJson<Issue>(responseBody);
                             // add to cache
                             foreach (Issue req in requirements)
                             {
@@ -366,17 +337,16 @@ namespace i5.VIAProMa.WebConnection
 
             if (ServiceManager.GetService<LearningLayersOidcService>().AccessToken == null || ServiceManager.GetService<LearningLayersOidcService>().AccessToken == "")
             {
-                Response resp = await Rest.GetAsync(path, null, -1, null, true);
-                ConnectionManager.Instance.CheckStatusCode(resp.ResponseCode);
-                string responseBody = await resp.GetResponseBody();
+                WebResponse<string> resp = await RestConnector.GetAsync(path, null);
+                ConnectionManager.Instance.CheckStatusCode(resp.Code);
                 if (!resp.Successful)
                 {
-                    Debug.LogError(resp.ResponseCode + ": " + responseBody);
-                    return new ApiResult<Issue[]>(resp.ResponseCode, responseBody);
+                    Debug.LogError(resp.Code + ": " + resp.Content);
+                    return new ApiResult<Issue[]>(resp.Code, resp.Content);
                 }
                 else
                 {
-                    Issue[] requirements = JsonArrayUtility.FromJson<Issue>(responseBody);
+                    Issue[] requirements = Utilities.JsonArrayUtility.FromJson<Issue>(resp.Content);
                     foreach (Issue req in requirements)
                     {
                         IssueCache.AddIssue(req);
@@ -413,18 +383,17 @@ namespace i5.VIAProMa.WebConnection
                     try
                     {
                         path = "https://requirements-bazaar.org/bazaar/" + "categories/" + categoryId + "/requirements?page=" + page + "&per_page=" + itemsPerPage;
-                        Response resp = await Rest.GetAsync(path, headers, -1, null, true);
-                        ConnectionManager.Instance.CheckStatusCode(resp.ResponseCode);
-                        string responseBody = await resp.GetResponseBody();
-                        responseBody = "{\"array\":" + responseBody + "}";
+                        WebResponse<string> resp = await RestConnector.GetAsync(path, headers);
+                        ConnectionManager.Instance.CheckStatusCode(resp.Code);
+                        string responseBody = "{\"array\":" + resp.Content + "}";
                         if (!resp.Successful)
                         {
-                            Debug.LogError(resp.ResponseCode + ": " + responseBody);
-                            return new ApiResult<Issue[]>(resp.ResponseCode, responseBody);
+                            Debug.LogError(resp.Code + ": " + responseBody);
+                            return new ApiResult<Issue[]>(resp.Code, responseBody);
                         }
                         else
                         {
-                            Issue[] requirements = JsonArrayUtility.FromJson<Issue>(responseBody);
+                            Issue[] requirements = Utilities.JsonArrayUtility.FromJson<Issue>(responseBody);
                             foreach (Issue req in requirements)
                             {
                                 IssueCache.AddIssue(req);


### PR DESCRIPTION
This pull-request changes all MRTK Webrequests to Webrequests from the i5 Toolkit and makes all the necessary adjustments that come with it. This works with the newest version of the i5-Toolkit-for-Unity currently only available on its develop branch. Thus, this pull-request should probably only be merged after the next version of the i5 Toolkit release.